### PR TITLE
feat: add symlink traversal

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -93,7 +93,7 @@ func walk(path string, info os.FileInfo, walkFn WalkFunc) error {
 		return err
 	}
 
-	if !info.IsDir() {
+	if !info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
Hi !

This patch allows symlink traversal. Walking over symlink can be useful to permit more versatile file system layout and limit the need to move data around.

Our particular use case is: we used to  `mc mirror` individual buckets of multiples clusters on a same backup folder, and now we want to use `mc mirror --watch --remove --overwrite` cluster wide and thus need a separate backup folder per cluster. But moving the data around is not possible would be too costly.